### PR TITLE
VCV based defaults. Uses release yyyy-mm-dd instead of from file name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,39 @@
 # clinvar-ftp-watcher
-Code for detecting new files on the clinvar ftp site. It works as follows:
-- read the last offset from the clinvar_ftp_watcher cloud topic containing dated files
+Code for detecting new files on the ClinVar FTP site. 
+
+It can be configured to look for new dated files of the form 'filename\_YYYY-MMDD.xml.gz'. By default, will look for the file 'ClinVarVariationRelease\_YYYY-MMDD.xml.gz'.
+
+It works as follows - all values in this description are default configured values:
+- read the last offset from the 'clinvar\_vcv\_ftp\watcher' containing records of dated files
 - retrieve the date of the last file recorded from that offset (there may be multiple dated files in a single recorded entry) 
-- use that date to compare against all of the dated files in https://ftp.ncbi.nlm.nih.gov/pub/clinvar/xml/clinvar_variation/weekly_release/
-- when there are more recent files, store them in a new message in clinvar_ftp_watcher topic.
-- initiate the clinvar-ingest workflow in google cloud.
+- use that date to compare against all of the 'ClinVarVariationRelease\_YYYY-MMDD.xml.gz' dated files in https://ftp.ncbi.nlm.nih.gov/pub/clinvar/xml/clinvar_variation/weekly_release/
+- when there are more recent files, store them in a new message in the configured cloud topic.
+- initiate the 'clinvar\_vcv\_ingest' cloud run job in google cloud.
 
-The above references to "dated files" are file names in the form ClinVarVariationRelease_YYYY-MMDD.xml.gz. These are the only files currently processed by this code. The weekly_release directory contains the following files:
-- ClinVarVariationRelease_00-latest_weekly.xml.gz - file that is a symbolic link to a dated release file. At the beginning of the month, ClinVar moves all of the dated files for the previous month to the parent clinvar_variation directory. As new weekly dated files are added to the weekly_release directory throught any given month, this file will be symbolically linked to the latest weekly release dated file.
+The 'weekly\_release' directory contains the following files:
+- 'ClinVarVariationRelease\_00-latest\_weekly.xml.gz' - file that is a symbolic link to a dated release file. At the beginning of the month, ClinVar moves all of the dated files for the previous month to the parent clinvar\_variation directory. As new weekly dated files are added to the weekly_release directory throught any given month, this file will be symbolically linked to the latest weekly release dated file.
 - md5 checksum files - for every .gz file in this directory there is a checksum file in the form .gz.md5
-- ClinVarVariationRelease_YYYY-MMDD.xml.gz - these are the dated files that this process reports on.
+- ClinVarVariationRelease\_YYYY-MMDD.xml.gz - these are the dated files that this process reports on.
 
-This code has been deployed as a cloud run job named clinvar-ftp-watcher and an associated cloud scheduler trigger scheduled to run every hour.
-
-For now, cloud builds can be invoked from the local source directory via:
-gcloud builds submit --project=clingen-dev --config ./.cloudbuild/docker-build-dev.cloudbuild.yaml --substitutions=COMMIT_SHA="testbuild" .
+This code has been deployed as a cloud run job named 'clinvar-vcv-ftp-watcher' and an associated cloud scheduler trigger scheduled to run every hour.
 
 A new build requires an edit to the cloud run job to update the container image.
 - Go to cloud run page - https://console.cloud.google.com/run/jobs?orgonly=true&project=clingen-dev&supportedpurview=organizationId
-- click on clinvar-ftp-watcher
-- on the job details page click "Edit"
-- change the "Container image url" by clicking "Select"
-- then select "Container registry"
-- open the gcr.io/clingen-dev/clinvar-ftp-watcher thingy
-- then click "select" on the latest build
-- click "update" on the cloud run job edit page
+Build and deploy scripts can be found in the misc/bin directory.
 
 Environment Variables:
 
-"DX_JAAS_CONFIG" must be defined, this is the kafka permission string
+"DX\_JAAS\_CONFIG" must be defined, this is the kafka permission string
 
-"CLINVAR_FTP_WATCHER_TOPIC" Kafka topic to read/write, defaults to 'clinvar_ftp_watcher' when not explicitly defined
+"CLINVAR\_FTP\_WATCHER\_TOPIC" Kafka topic to read/write, defaults to 'clinvar-vcv-ftp-watcher' when not explicitly defined
 
-"NCBI_CLINVAR_WEEKLY_FTP_DIR" defaults to "/pub/clinvar/xml/clinvar_variation/weekly_release" when not explicitly defined
-"NCBI_CLINVAR_FTP_SITE" defaults to "https://ftp.ncbi.nlm.nih.gov" when not explicitly defined
+"NCBI\_CLINVAR\_WEEKLY\_FTP\_DIR" defaults to "/pub/clinvar/xml/clinvar\_variation/weekly\_release" when not explicitly defined
+"NCBI\_CLINVAR\_FTP\_SITE" defaults to "https://ftp.ncbi.nlm.nih.gov" when not explicitly defined
+"NCBI\_CLINVAR\_FILE\_NAME\_BASE" - the base file name to look for - defaults to 'ClinVarVariationRelease' when not explicitly defined
 
-"GCP_WORKFLOW_PROJECT_ID" this is the GCP Project ID where the workflow resides, defaults to "clingen-dev" when not explicitly defined
-"GCP_WORKFLOW_LOCATION" this is the region where the workflow resides, such as "us-central1" when not explicitly defined
-"GCP_WORKFLOW_NAME" this is the name of the workflow to invoke, such as "clinvar-ingest" when not explicitly defined
+"GCP\_WORKFLOW\_PROJECT\_ID" this is the GCP Project ID where the workflow resides, defaults to "clingen-dev" when not explicitly defined
+"GCP\_WORKFLOW\_LOCATION" this is the region where the workflow resides, such as "us-central1" when not explicitly defined
+"GCP\_WORKFLOW\_NAME" this is the name of the workflow to invoke, such as "clinvar-ingest" when not explicitly defined
 
 Command Line Arguments:
 --kafka = do not write the release information to the kafka topic.

--- a/misc/bin/deploy-job.sh
+++ b/misc/bin/deploy-job.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
+# Build and deploy this project source code as a GCP cloud run job.
+#
+# Usage: shell> instance="clinvar-vcv-ftp-watcher" sh ./misc/bin//deploy-job.sh
+#    or: shell> instance="clinvar-rcv-ftp-watcher-xxx" sh ./misc/bin/deploy-job.sh           
 
-set -xeo pipefail
+set -xo pipefail
+
+if [ -z "$instance" ]; then
+    echo "'instance' must set in environment. It defines the name of the cloud run job deployment."
+    echo "It should have either 'rcv' or 'vcv' in the name."
+    exit -1
+fi
+
+echo "${instance}" | egrep -i "vcv|rcv" > /dev/null
+if [ $? -ne 0 ]; then
+    echo "'instance' must have 'rcv' or 'vcv' in the name."
+    exit -1
+fi
 
 if [ -z "$branch" ]; then
     branch=$(git rev-parse --abbrev-ref HEAD)
@@ -16,16 +32,10 @@ fi
 echo "Branch: $branch"
 echo "Commit: $commit"
 
-set -u
+set -ue
 
-if [ "$branch" == "main" ]; then
-    instance_name="clinvar-ftp-watcher"
-else
-    instance_name="clinvar-ftp-watcher-${branch}"
-fi
 clinvar_ftp_watcher_bucket="clinvar-ftp-watcher"
-
-region="us-central1"
+region="us-east1"
 # project=$(gcloud config get project)
 image=gcr.io/clingen-dev/clinvar-ftp-watcher:$commit
 deployment_service_account=clinvar-ftp-watcher-deployment@clingen-dev.iam.gserviceaccount.com
@@ -47,24 +57,42 @@ tar --no-xattrs -c \
 gcloud builds submit \
     --substitutions="COMMIT_SHA=${commit}" \
     --config .cloudbuild/docker-build-dev.cloudbuild.yaml \
-    --gcs-log-dir=gs://${clinvar_ftp_watcher_bucket}/build/logs \
+    --gcs-log-dir=gs://$clinvar_ftp_watcher_bucket/build/logs \
     archive.tar.gz
 
 ################################################################
 # Deploy job
-if gcloud run jobs list --region us-central1 | awk '{print $2}' | grep "^$instance_name$"  ; then
-    echo "Cloud Run Job $instance_name already exists - updating it"
+if gcloud run jobs list --region $region | awk '{print $2}' | grep "^${instance}$"  ; then
+    echo "Cloud Run Job $instance already exists - updating it"
     command="update"
 else
-    echo "Cloud Run Job $instance_name doesn't exist - creating it"
+    echo "Cloud Run Job $instance doesn't exist - creating it"
     command="create"
 fi
-gcloud run jobs $command $instance_name \
+
+# clinvar_ftp_watcher env defaults are variant biased
+vcv_cloud_run_deploy="gcloud run jobs ${command} ${instance} \
     --cpu=1 \
     --image=$image \
     --max-retries=0 \
-    --region=$region \
-    --service-account=$deployment_service_account \
-    --set-secrets=DX_JAAS_CONFIG=dx-prod-jaas:latest
+    --region=${region} \
+    --service-account=${deployment_service_account} \
+    --set-secrets=DX_JAAS_CONFIG=dx-prod-jaas:latest"
 
+# override variant biased env vars with rcv specifics
+rcv_cloud_run_deploy="${vcv_cloud_run_deploy} \
+    --set-env-vars=CLINVAR_FTP_WATCHER_TOPIC=clinvar-rcv-ftp-watcher \
+    --set-env-vars=NCBI_CLINVAR_WEEKLY_FTP_DIR=/pub/clinvar/xml/RCV_release/weekly_release \
+    --set-env-vars=NCBI_CLINVAR_FILE_NAME_BASE=ClinVarRCVRelease \
+    --set-env-vars=GCP_WORKFLOW_LOCATION=${region} \
+    --set-env-vars=GCP_WORKFLOW_NAME=clinvar-rcv-ingest"
+
+set +e
+
+echo "${instance}" | grep -i "rcv" > /dev/null
+if [ $? -eq 0 ]; then
+    $rcv_cloud_run_deploy
+else
+    $vcv_cloud_run_deploy
+fi
 

--- a/src/watcher/watcher.clj
+++ b/src/watcher/watcher.clj
@@ -58,7 +58,7 @@
                        "Last Modified" (.format ftpparse/ftp-time (entry "Last Modified"))
                        "Directory" (ftpparse/weekly-ftp-dir)
                        "Host" (ftpparse/ftp-site)
-                       "Release Date" (ftpparse/extract-date-from-file (entry "Name"))}))
+                       "Release Date" (.format ftpparse/ftp-time-ymd (entry "Released"))}))
           []
           (:files current)))
 
@@ -101,10 +101,10 @@
 
 
 (comment
-  (let [file-details (process-file-details  (get-latest-files-since #inst "2023-01-06"))]
+  (let [file-details (process-file-details  (get-latest-files-since #inst "2024-06-01"))]
     (doseq [release file-details]
       ((workflow/initiate-workflow (json/write-str release))))))
 
 
 (comment
-  (-> (ftpparse/ftp-since #inst "2023-12-30")))
+  (-> (ftpparse/ftp-since #inst "2024-06-01")))

--- a/src/watcher/watcher.clj
+++ b/src/watcher/watcher.clj
@@ -58,7 +58,7 @@
                        "Last Modified" (.format ftpparse/ftp-time (entry "Last Modified"))
                        "Directory" (ftpparse/weekly-ftp-dir)
                        "Host" (ftpparse/ftp-site)
-                       "Release Date" (.format ftpparse/ftp-time-ymd (entry "Released"))}))
+                       "Release Date" (ftpparse/extract-date-from-file (entry "Name"))}))
           []
           (:files current)))
 

--- a/src/watcher/workflow.clj
+++ b/src/watcher/workflow.clj
@@ -6,8 +6,8 @@
 
 
 (def DEFAULT_GCP_WORKFLOW_PROJECT_ID "clingen-dev")
-(def DEFAULT_GCP_WORKFLOW_LOCATION "us-central1") 
-(def DEFAULT_GCP_WORKFLOW_NAME "clinvar-ingest")
+(def DEFAULT_GCP_WORKFLOW_LOCATION "us-east1") 
+(def DEFAULT_GCP_WORKFLOW_NAME "clinvar-vcv-ingest")
 
 ;; TODO s/b a macro?
 (defn gcp-workflow-project-id []


### PR DESCRIPTION
Deployment script handles vcv and rcv watcher deployments.